### PR TITLE
Added in zip code handling for call_geolocator()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,4 @@ Imports:
     sf, 
     dplyr, 
     methods
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -66,7 +66,7 @@ append_geoid <- function(address, geoid_type = 'block') {
 #' @param street A character string indicating a street name and number
 #' @param city A character string indicating a city
 #' @param state A two-digit character string with a state postal code
-#' @param zip A five-digit character string with a postal zip code. Optional paramater.
+#' @param zip A five-digit character string with a postal zip code. Optional parameter.
 #'
 #' @return A character string representing the Census block of the supplied
 #'   address.

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -66,6 +66,7 @@ append_geoid <- function(address, geoid_type = 'block') {
 #' @param street A character string indicating a street name and number
 #' @param city A character string indicating a city
 #' @param state A two-digit character string with a state postal code
+#' @param zip A five-digit character string with a postal zip code. Optional paramater.
 #'
 #' @return A character string representing the Census block of the supplied
 #'   address.
@@ -75,15 +76,35 @@ append_geoid <- function(address, geoid_type = 'block') {
 #'
 #' @export
 #'
-call_geolocator <- function(street, city, state) {
-  # Build url
+call_geolocator <- function(street, city, state, zip = NA) {
+
   call_start <- "https://geocoding.geo.census.gov/geocoder/geographies/address?"
 
-  url <- paste0(
-    "street=", utils::URLencode(street),
-    "&city=", utils::URLencode(city),
-    "&state=", state
-  )
+  if(is.na(zip)){
+    # Build url when zip is default/NA
+    url <- paste0(
+      "street=", utils::URLencode(street),
+      "&city=", utils::URLencode(city),
+      "&state=", state
+    )}
+
+  if(!is.na(zip)){
+    # Build url when zip is not default/NA
+    if(class(zip) == "character" & nchar(zip) == 5 & !grepl("\\D", zip)){
+      url <- paste0(
+        "street=", utils::URLencode(street),
+        "&city=", utils::URLencode(city),
+        "&state=", state,
+        "&zip=", zip
+      )} else {
+        message("'zip' (", paste0(zip), ") was not a 5-character-long string composed of :digits:. Using only street, city, state.")
+        url <- paste0(
+          "street=", utils::URLencode(street),
+          "&city=", utils::URLencode(city),
+          "&state=", state
+        )
+      }
+    }
 
   call_end <- "&benchmark=Public_AR_Census2010&vintage=Census2010_Census2010&layers=14&format=json"
 

--- a/man/alaska_native_regional_corporations.Rd
+++ b/man/alaska_native_regional_corporations.Rd
@@ -31,3 +31,4 @@ Other native/tribal geometries functions: \code{\link{native_areas}},
   \code{\link{tribal_census_tracts}},
   \code{\link{tribal_subdivisions_national}}
 }
+\concept{native/tribal geometries functions}

--- a/man/area_water.Rd
+++ b/man/area_water.Rd
@@ -43,3 +43,4 @@ plot(dallas_water)
 Other water functions: \code{\link{coastline}},
   \code{\link{linear_water}}
 }
+\concept{water functions}

--- a/man/block_groups.Rd
+++ b/man/block_groups.Rd
@@ -65,3 +65,4 @@ Other general area functions: \code{\link{blocks}},
   \code{\link{states}}, \code{\link{tracts}},
   \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/blocks.Rd
+++ b/man/blocks.Rd
@@ -65,3 +65,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{states}}, \code{\link{tracts}},
   \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/call_geolocator.Rd
+++ b/man/call_geolocator.Rd
@@ -4,7 +4,7 @@
 \alias{call_geolocator}
 \title{Call geolocator for one address}
 \usage{
-call_geolocator(street, city, state)
+call_geolocator(street, city, state, zip = NA)
 }
 \arguments{
 \item{street}{A character string indicating a street name and number}
@@ -12,6 +12,8 @@ call_geolocator(street, city, state)
 \item{city}{A character string indicating a city}
 
 \item{state}{A two-digit character string with a state postal code}
+
+\item{zip}{A five-digit character string with a postal zip code. Optional paramater.}
 }
 \value{
 A character string representing the Census block of the supplied

--- a/man/coastline.Rd
+++ b/man/coastline.Rd
@@ -50,3 +50,4 @@ gg
 Other water functions: \code{\link{area_water}},
   \code{\link{linear_water}}
 }
+\concept{water functions}

--- a/man/combined_statistical_areas.Rd
+++ b/man/combined_statistical_areas.Rd
@@ -4,8 +4,8 @@
 \alias{combined_statistical_areas}
 \title{Download a combined statistical areas shapefile into R}
 \usage{
-combined_statistical_areas(cb = FALSE, resolution = "500k", year = NULL,
-  ...)
+combined_statistical_areas(cb = FALSE, resolution = "500k",
+  year = NULL, ...)
 }
 \arguments{
 \item{cb}{If cb is set to TRUE, download a generalized (1:500k)
@@ -33,3 +33,4 @@ Other metro area functions: \code{\link{core_based_statistical_areas}},
   \code{\link{metro_divisions}}, \code{\link{new_england}},
   \code{\link{urban_areas}}
 }
+\concept{metro area functions}

--- a/man/congressional_districts.Rd
+++ b/man/congressional_districts.Rd
@@ -4,7 +4,8 @@
 \alias{congressional_districts}
 \title{Download a congressional districts shapefile for the 114th Congress into R}
 \usage{
-congressional_districts(cb = FALSE, resolution = "500k", year = NULL, ...)
+congressional_districts(cb = FALSE, resolution = "500k", year = NULL,
+  ...)
 }
 \arguments{
 \item{cb}{If cb is set to TRUE, download a generalized (1:500k)
@@ -53,3 +54,4 @@ leaflet(cd114) \%>\%
 Other legislative district functions: \code{\link{state_legislative_districts}},
   \code{\link{voting_districts}}
 }
+\concept{legislative district functions}

--- a/man/core_based_statistical_areas.Rd
+++ b/man/core_based_statistical_areas.Rd
@@ -4,8 +4,8 @@
 \alias{core_based_statistical_areas}
 \title{Download a core-based statistical area shapefile into R}
 \usage{
-core_based_statistical_areas(cb = FALSE, resolution = "500k", year = NULL,
-  ...)
+core_based_statistical_areas(cb = FALSE, resolution = "500k",
+  year = NULL, ...)
 }
 \arguments{
 \item{cb}{If cb is set to TRUE, download a generalized (1:500k)
@@ -36,3 +36,4 @@ Other metro area functions: \code{\link{combined_statistical_areas}},
   \code{\link{metro_divisions}}, \code{\link{new_england}},
   \code{\link{urban_areas}}
 }
+\concept{metro area functions}

--- a/man/counties.Rd
+++ b/man/counties.Rd
@@ -4,8 +4,8 @@
 \alias{counties}
 \title{Download a US Counties shapefile into R, and optionally subset by state}
 \usage{
-counties(state = NULL, cb = FALSE, resolution = "500k", year = NULL,
-  ...)
+counties(state = NULL, cb = FALSE, resolution = "500k",
+  year = NULL, ...)
 }
 \arguments{
 \item{state}{The two-digit FIPS code (string) of the state you want, or a
@@ -79,3 +79,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{school_districts}}, \code{\link{states}},
   \code{\link{tracts}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/county_subdivisions.Rd
+++ b/man/county_subdivisions.Rd
@@ -4,7 +4,8 @@
 \alias{county_subdivisions}
 \title{Download a county subdivision shapefile into R}
 \usage{
-county_subdivisions(state, county = NULL, cb = FALSE, year = NULL, ...)
+county_subdivisions(state, county = NULL, cb = FALSE, year = NULL,
+  ...)
 }
 \arguments{
 \item{state}{The two-digit FIPS code (string) of the state you want. Can also
@@ -50,3 +51,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{school_districts}}, \code{\link{states}},
   \code{\link{tracts}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/divisions.Rd
+++ b/man/divisions.Rd
@@ -35,3 +35,4 @@ leaflet(divs) \%>\%
 Other national cartographic boundary functions: \code{\link{nation}},
   \code{\link{regions}}
 }
+\concept{national cartographic boundary functions}

--- a/man/geo_join.Rd
+++ b/man/geo_join.Rd
@@ -4,7 +4,8 @@
 \alias{geo_join}
 \title{Easily merge a data frame to a spatial data frame}
 \usage{
-geo_join(spatial_data, data_frame, by_sp, by_df, by = NULL, how = "left")
+geo_join(spatial_data, data_frame, by_sp, by_df, by = NULL,
+  how = "left")
 }
 \arguments{
 \item{spatial_data}{A spatial data frame to which you want to merge data.}

--- a/man/linear_water.Rd
+++ b/man/linear_water.Rd
@@ -45,3 +45,4 @@ plot(dallas_water)
 Other water functions: \code{\link{area_water}},
   \code{\link{coastline}}
 }
+\concept{water functions}

--- a/man/metro_divisions.Rd
+++ b/man/metro_divisions.Rd
@@ -25,3 +25,4 @@ Other metro area functions: \code{\link{combined_statistical_areas}},
   \code{\link{core_based_statistical_areas}},
   \code{\link{new_england}}, \code{\link{urban_areas}}
 }
+\concept{metro area functions}

--- a/man/nation.Rd
+++ b/man/nation.Rd
@@ -35,3 +35,4 @@ leaflet(boundary) \%>\%
 Other national cartographic boundary functions: \code{\link{divisions}},
   \code{\link{regions}}
 }
+\concept{national cartographic boundary functions}

--- a/man/native_areas.Rd
+++ b/man/native_areas.Rd
@@ -51,3 +51,4 @@ Other native/tribal geometries functions: \code{\link{alaska_native_regional_cor
   \code{\link{tribal_census_tracts}},
   \code{\link{tribal_subdivisions_national}}
 }
+\concept{native/tribal geometries functions}

--- a/man/new_england.Rd
+++ b/man/new_england.Rd
@@ -51,3 +51,4 @@ Other metro area functions: \code{\link{combined_statistical_areas}},
   \code{\link{core_based_statistical_areas}},
   \code{\link{metro_divisions}}, \code{\link{urban_areas}}
 }
+\concept{metro area functions}

--- a/man/places.Rd
+++ b/man/places.Rd
@@ -54,3 +54,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{school_districts}}, \code{\link{states}},
   \code{\link{tracts}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/primary_roads.Rd
+++ b/man/primary_roads.Rd
@@ -36,3 +36,4 @@ plot(rds)
 Other transportation functions: \code{\link{primary_secondary_roads}},
   \code{\link{rails}}, \code{\link{roads}}
 }
+\concept{transportation functions}

--- a/man/primary_secondary_roads.Rd
+++ b/man/primary_secondary_roads.Rd
@@ -44,3 +44,4 @@ plot(rds)
 Other transportation functions: \code{\link{primary_roads}},
   \code{\link{rails}}, \code{\link{roads}}
 }
+\concept{transportation functions}

--- a/man/pumas.Rd
+++ b/man/pumas.Rd
@@ -59,3 +59,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{school_districts}}, \code{\link{states}},
   \code{\link{tracts}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/rails.Rd
+++ b/man/rails.Rd
@@ -35,3 +35,4 @@ Other transportation functions: \code{\link{primary_roads}},
   \code{\link{primary_secondary_roads}},
   \code{\link{roads}}
 }
+\concept{transportation functions}

--- a/man/regions.Rd
+++ b/man/regions.Rd
@@ -35,3 +35,4 @@ leaflet(us_regions) \%>\%
 Other national cartographic boundary functions: \code{\link{divisions}},
   \code{\link{nation}}
 }
+\concept{national cartographic boundary functions}

--- a/man/roads.Rd
+++ b/man/roads.Rd
@@ -62,3 +62,4 @@ Other transportation functions: \code{\link{primary_roads}},
   \code{\link{primary_secondary_roads}},
   \code{\link{rails}}
 }
+\concept{transportation functions}

--- a/man/school_districts.Rd
+++ b/man/school_districts.Rd
@@ -58,3 +58,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{pumas}}, \code{\link{states}},
   \code{\link{tracts}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/state_legislative_districts.Rd
+++ b/man/state_legislative_districts.Rd
@@ -49,3 +49,4 @@ leaflet(leg) \%>\%
 Other legislative district functions: \code{\link{congressional_districts}},
   \code{\link{voting_districts}}
 }
+\concept{legislative district functions}

--- a/man/states.Rd
+++ b/man/states.Rd
@@ -50,3 +50,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{pumas}}, \code{\link{school_districts}},
   \code{\link{tracts}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/tigris-exports.Rd
+++ b/man/tigris-exports.Rd
@@ -10,8 +10,4 @@ The following functions are imported and then re-exported
 from the tigris package to enable use of the magrittr
 pipe operator and the sp plot method without any additional
 library calls
-
-Pipe operator
-
-Spatial plotting
 }

--- a/man/tracts.Rd
+++ b/man/tracts.Rd
@@ -73,3 +73,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{pumas}}, \code{\link{school_districts}},
   \code{\link{states}}, \code{\link{zctas}}
 }
+\concept{general area functions}

--- a/man/tribal_block_groups.Rd
+++ b/man/tribal_block_groups.Rd
@@ -50,3 +50,4 @@ Other native/tribal geometries functions: \code{\link{alaska_native_regional_cor
   \code{\link{tribal_census_tracts}},
   \code{\link{tribal_subdivisions_national}}
 }
+\concept{native/tribal geometries functions}

--- a/man/tribal_census_tracts.Rd
+++ b/man/tribal_census_tracts.Rd
@@ -45,3 +45,4 @@ Other native/tribal geometries functions: \code{\link{alaska_native_regional_cor
   \code{\link{tribal_block_groups}},
   \code{\link{tribal_subdivisions_national}}
 }
+\concept{native/tribal geometries functions}

--- a/man/tribal_subdivisions_national.Rd
+++ b/man/tribal_subdivisions_national.Rd
@@ -40,3 +40,4 @@ Other native/tribal geometries functions: \code{\link{alaska_native_regional_cor
   \code{\link{tribal_block_groups}},
   \code{\link{tribal_census_tracts}}
 }
+\concept{native/tribal geometries functions}

--- a/man/urban_areas.Rd
+++ b/man/urban_areas.Rd
@@ -29,3 +29,4 @@ Other metro area functions: \code{\link{combined_statistical_areas}},
   \code{\link{core_based_statistical_areas}},
   \code{\link{metro_divisions}}, \code{\link{new_england}}
 }
+\concept{metro area functions}

--- a/man/voting_districts.Rd
+++ b/man/voting_districts.Rd
@@ -38,3 +38,4 @@ plot(ia)
 Other legislative district functions: \code{\link{congressional_districts}},
   \code{\link{state_legislative_districts}}
 }
+\concept{legislative district functions}

--- a/man/zctas.Rd
+++ b/man/zctas.Rd
@@ -4,7 +4,8 @@
 \alias{zctas}
 \title{Download a Zip Code Tabulation Area (ZCTA) shapefile into R}
 \usage{
-zctas(cb = FALSE, starts_with = NULL, year = NULL, state = NULL, ...)
+zctas(cb = FALSE, starts_with = NULL, year = NULL, state = NULL,
+  ...)
 }
 \arguments{
 \item{cb}{If cb is set to TRUE, download a generalized (1:500k)
@@ -62,3 +63,4 @@ Other general area functions: \code{\link{block_groups}},
   \code{\link{pumas}}, \code{\link{school_districts}},
   \code{\link{states}}, \code{\link{tracts}}
 }
+\concept{general area functions}


### PR DESCRIPTION
Basic error handling included, reverts to the normal street, city, state if the zip code is not in the correct format (5-character-long string composed of only :digits:).