### PR TITLE
replace httr::GET() with httr:RETRY()

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -72,7 +72,7 @@ append_geoid <- function(address, geoid_type = 'block') {
 #'   address.
 #'
 #' importFrom utils URLencode
-#' importFrom httr GET stop_for_status
+#' @importFrom httr RETRY stop_for_status
 #'
 #' @export
 #'
@@ -111,7 +111,7 @@ call_geolocator <- function(street, city, state, zip = NA) {
   url_full <- paste0(call_start, url, call_end)
 
   # Check response
-  r <- httr::GET(url_full)
+  r <- httr::RETRY('GET', url_full, terminate_on = c(404))
   httr::stop_for_status(r)
   response <- httr::content(r)
   if (length(response$result$addressMatches) == 0) {
@@ -141,7 +141,7 @@ call_geolocator <- function(street, city, state, zip = NA) {
 #'   lat/lon.
 #'
 #' @importFrom utils URLencode
-#' @importFrom httr GET stop_for_status
+#' @importFrom httr RETRY stop_for_status
 #'
 #' @author Josie Kressner, \email{josie@@transportfoundry.com}
 #' @author Mark Richards, \email{Mark.Richards.002@@gmail.com}
@@ -168,7 +168,7 @@ call_geolocator_latlon <- function(lat, lon, benchmark, vintage) {
   url_full <- paste0(call_start, url, benchmark0, vintage0)
   #print(url_full)
   # Check response
-  r <- httr::GET(url_full)
+  r <- httr::RETRY('GET', url_full, terminate_on = c(404))
   httr::stop_for_status(r)
   response <- httr::content(r)
   if (length(response$result$geographies$`2010 Census Blocks`[[1]]$GEOID) == 0) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -84,11 +84,11 @@ load_tiger <- function(url,
         # Change back if you get additional info.
 
         if (progress_bar) {
-          try(GET(url,
+          try(RETRY("GET", url,
                   write_disk(file_loc, overwrite=refresh),
                   progress(type="down")), silent=TRUE)
         } else {
-          try(GET(url,
+          try(RETRY("GET", url,
                   write_disk(file_loc, overwrite=refresh)),
                   silent=TRUE)
         }
@@ -121,11 +121,11 @@ load_tiger <- function(url,
             # try(download.file(url, file_loc, mode = "wb"))
 
             if (progress_bar) {
-              try(GET(url,
+              try(RETRY("GET", url,
                       write_disk(file_loc, overwrite=TRUE),
                       progress(type="down")), silent=TRUE)
             } else {
-              try(GET(url,
+              try(RETRY("GET", url,
                       write_disk(file_loc, overwrite=TRUE)),
                       silent=TRUE)
             }
@@ -193,10 +193,10 @@ load_tiger <- function(url,
     file_loc <- file.path(tmp, tiger_file)
 
     if (progress_bar) {
-      try(GET(url, write_disk(file_loc),
+      try(RETRY("GET", url, write_disk(file_loc),
               progress(type = "down")), silent = TRUE)
     } else {
-      try(GET(url, write_disk(file_loc)),
+      try(RETRY("GET", url, write_disk(file_loc)),
               silent = TRUE)
     }
 


### PR DESCRIPTION
Thanks for this awesome project @walkerke!

In this PR, I'd like to propose swapping out calls to `httr::GET()` etc. with `httr::RETRY()`. This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on https://github.com/chircollab/chircollab20/issues/1 as part of Chicago R Collab, an R 'unconference' in Chicago.