### PR TITLE
Pass `...` parameters through to `load_tiger` for nation, divisions, …

### DIFF
--- a/R/national.R
+++ b/R/national.R
@@ -48,7 +48,7 @@ regions <- function(resolution = '500k', year = NULL, ...) {
   url <- sprintf("https://www2.census.gov/geo/tiger/GENZ%s/shp/cb_%s_us_region_%s.zip",
                  cyear, cyear, resolution)
 
-  rgns <- load_tiger(url, tigris_type = "region")
+  rgns <- load_tiger(url, tigris_type = "region", ...)
 
   return(rgns)
 
@@ -104,7 +104,7 @@ divisions <- function(resolution = '500k', year = NULL, ...) {
   url <- sprintf("https://www2.census.gov/geo/tiger/GENZ%s/shp/cb_%s_us_division_%s.zip",
                  cyear, cyear, resolution)
 
-  div <- load_tiger(url, tigris_type = "division")
+  div <- load_tiger(url, tigris_type = "division", ...)
 
   return(div)
 
@@ -160,7 +160,7 @@ nation <- function(resolution = '5m', year = NULL, ...) {
   url <- sprintf("https://www2.census.gov/geo/tiger/GENZ%s/shp/cb_%s_us_nation_%s.zip",
                  cyear, cyear, resolution)
 
-  nat <- load_tiger(url, tigris_type = "nation")
+  nat <- load_tiger(url, tigris_type = "nation", ...)
 
   return(nat)
 


### PR DESCRIPTION
…and region

Additional parameters weren't being passed through to `load_tiger`, even though this behavior is documented.