### PR TITLE
Remove zip files after they have been unzipped. Closes #111

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -102,6 +102,11 @@ load_tiger <- function(url,
         unzip_tiger <- function() {
           unzip(file_loc, exdir = cache_dir, overwrite=TRUE)
         }
+        remove_zip_tiger <- function() {
+          if (file.exists(file_loc) && file.exists(shp_loc)) {
+            invisible(file.remove(file_loc))
+          }
+        }
 
         # Logic for handling download errors and re-downloading
         t <- tryCatch(unzip_tiger(), warning = function(w) w)
@@ -144,6 +149,7 @@ load_tiger <- function(url,
         } else {
 
           unzip_tiger()
+          remove_zip_tiger()
 
         }
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -76,6 +76,9 @@ load_tiger <- function(url,
 
     if (file.exists(cache_dir)) {
 
+      shape <- gsub(".zip", "", tiger_file)
+      shape <- gsub("_shp", "", shape) # for historic tracts
+
       file_loc <- file.path(cache_dir, tiger_file)
 
       if (refresh | !file.exists(file_loc)) {
@@ -92,9 +95,6 @@ load_tiger <- function(url,
 
 
       }
-
-      shape <- gsub(".zip", "", tiger_file)
-      shape <- gsub("_shp", "", shape) # for historic tracts
 
       if (refresh | !file.exists(file.path(cache_dir,
                                  sprintf("%s.shp", shape)))) {
@@ -124,11 +124,6 @@ load_tiger <- function(url,
                       write_disk(file_loc, overwrite=TRUE)),
                       silent=TRUE)
             }
-
-
-
-            shape <- gsub(".zip", "", tiger_file)
-            shape <- gsub("_shp", "", shape)
 
             t <- tryCatch(unzip_tiger(), warning = function(w) w)
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -80,8 +80,9 @@ load_tiger <- function(url,
       shape <- gsub("_shp", "", shape) # for historic tracts
 
       file_loc <- file.path(cache_dir, tiger_file)
+      shp_loc  <- file.path(cache_dir, sprintf("%s.shp", shape))
 
-      if (refresh | !file.exists(file_loc)) {
+      if (refresh | !file.exists(shp_loc)) {
 
         if (progress_bar) {
           try(GET(url,
@@ -96,8 +97,7 @@ load_tiger <- function(url,
 
       }
 
-      if (refresh | !file.exists(file.path(cache_dir,
-                                 sprintf("%s.shp", shape)))) {
+      if (refresh | !file.exists(shp_loc)) {
 
         unzip_tiger <- function() {
           unzip(file_loc, exdir = cache_dir, overwrite=TRUE)


### PR DESCRIPTION
Hi! This is the solution I came up with to remove the zip files. It works at the level of `load_tigris()`, so it will remove the zip files for any type of shapefiles after they have been downloaded (not only the ZCTAs, which was the use case I described in the issue). I tested it with a couple of functions (e.g. `zctas()`, `regions()`, `area_water()`) and it works fine, but I didn't actulaly write down any formal tests. Hope this is fine and that it also works on your end 😄 