### PR TITLE
Fixed tigris_cache_dir so it replaces the correct line.

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -28,7 +28,7 @@ tigris_cache_dir <- function(path) {
 
   if (isTRUE(any(grepl("TIGRIS_CACHE_DIR", check)))) {
     oldenv <- read.table(renv, stringsAsFactors = FALSE)
-    newenv <- oldenv[-grep("TIGRIS_CACHE_DIR", oldenv),]
+    newenv <- oldenv[!grepl("TIGRIS_CACHE_DIR", oldenv$V1), ]
     write.table(newenv, renv, quote = FALSE, sep = "\n",
                 col.names = FALSE, row.names = FALSE)
   }


### PR DESCRIPTION
When applied to an .Renviron file that already has TIGRIS_CACHE_DIR, the current function removes line 1 of .Renviron, not the line with TIGRIS_CACHE_DIR.  