### PR TITLE
Add 2021 TIGER/Line support to congressional_districts() and blocks()

### DIFF
--- a/R/enumeration_units.R
+++ b/R/enumeration_units.R
@@ -888,7 +888,7 @@ blocks <- function(state, county = NULL, year = NULL, ...) {
 
   if (year >= 2014) {
 
-    if (year == 2020) {
+    if (year %in% 2020:2021) {
 
       # New block logic for 2020
       url <- sprintf("https://www2.census.gov/geo/tiger/TIGER%s/TABBLOCK20/tl_%s_%s_tabblock20.zip",

--- a/R/legislative.R
+++ b/R/legislative.R
@@ -46,7 +46,7 @@ congressional_districts <- function(state = NULL, cb = FALSE, resolution = '500k
          call. = FALSE)
   }
 
-  if (year %in% 2018:2020) {
+  if (year %in% 2018:2021) {
     congress <- "116"
   } else if (year %in% 2016:2017) {
     congress <- "115"


### PR DESCRIPTION
Currently, trying to download the 2021 vintage congressional district boundaries causes an error:

```
> tigris::congressional_districts(year = 2021)
Error in sprintf("https://www2.census.gov/geo/tiger/TIGER%s/CD/tl_%s_us_cd%s.zip",  : 
  object 'congress' not found
```

The 2021 TIGER/Line congressional districts still correspond to the 116th Congress <https://www.census.gov/programs-surveys/geography/technical-documentation/user-note/cd-sld-note.html>