### PR TITLE
Document output for roads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,4 +35,5 @@ Imports:
     sf, 
     dplyr, 
     methods
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
+Roxygen: list(markdown = TRUE)

--- a/R/transportation.R
+++ b/R/transportation.R
@@ -5,16 +5,28 @@
 #' rural roads, city streets, vehicular trails (4WD), ramps, service drives,
 #' walkways, stairways, alleys, and private roads."
 #'
-#' @param state The two-digit FIPS code of the state of the county you'd like
-#'        to download the roads for. Can also be state name or abbreviation
+#' @param state A character vector of the two-digit FIPS code of the state of the county
+#'        you'd like to download the roads for. Can also be state name or abbreviation
 #'        (case-insensitive).
-#' @param county The three-digit FIPS code of the county you'd like the roads for.
-#'        Can also be a county name.
+#' @param county A character vector of the three-digit FIPS code of the county you'd like
+#'        the roads for. Can also be a county name.
 #' @inheritParams load_tiger_doc_template
 #' @inheritSection load_tiger_doc_template Additional Arguments
 #' @family transportation functions
 #' @seealso \url{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2020/TGRSHP2020_TechDoc.pdf}
 #' @export
+#' @returns
+#' an sf object with columns
+#'  - `LINEARID`: a unique line feature identifier [(source)](https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf)
+#'  - `FULLNAME`: display name [(source)](https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf)
+#'  - `RTTYP`: describes the types of roads used [(source)](https://www.census.gov/library/reference/code-lists/route-type-codes.html). Possible values are:
+#'    - "C": county
+#'    - "I": interstate
+#'    - "M": common name
+#'    - "O": other
+#'    - "S": state regonized
+#'    - "U": U.S.
+#'  - `MTFCC`: 5-digit geographic code assignment [(see annual assignments)](https://www.census.gov/library/reference/code-lists/mt-feature-class-codes.html)
 #' @examples \dontrun{
 #' library(tigris)
 #' library(ggplot2)
@@ -81,6 +93,7 @@ roads <- function(state, county, year = NULL, ...) {
 #'
 #' @inheritParams load_tiger_doc_template
 #' @inheritSection load_tiger_doc_template Additional Arguments
+#' @inherit roads return
 #' @family transportation functions
 #' @seealso \url{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2020/TGRSHP2020_TechDoc.pdf}
 #' @export
@@ -136,6 +149,7 @@ primary_roads <- function(year = NULL, ...) {
 #'        (case-insensitive).
 #' @inheritParams load_tiger_doc_template
 #' @inheritSection load_tiger_doc_template Additional Arguments
+#' @inherit roads return
 #' @family transportation functions
 #' @seealso \url{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2020/TGRSHP2020_TechDoc.pdf}
 #' @export

--- a/man/primary_roads.Rd
+++ b/man/primary_roads.Rd
@@ -11,6 +11,23 @@ primary_roads(year = NULL, ...)
 
 \item{...}{arguments to be passed to internal function \code{load_tiger}, which is not exported. See Additional Arguments.}
 }
+\value{
+an sf object with columns
+\itemize{
+\item \code{LINEARID}: a unique line feature identifier \href{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf}{(source)}
+\item \code{FULLNAME}: display name \href{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf}{(source)}
+\item \code{RTTYP}: describes the types of roads used \href{https://www.census.gov/library/reference/code-lists/route-type-codes.html}{(source)}. Possible values are:
+\itemize{
+\item "C": county
+\item "I": interstate
+\item "M": common name
+\item "O": other
+\item "S": state regonized
+\item "U": U.S.
+}
+\item \code{MTFCC}: 5-digit geographic code assignment \href{https://www.census.gov/library/reference/code-lists/mt-feature-class-codes.html}{(see annual assignments)}
+}
+}
 \description{
 From the Census Bureau: "Primary roads are generally divided,
 limited-access highways within the Federal interstate highway

--- a/man/primary_secondary_roads.Rd
+++ b/man/primary_secondary_roads.Rd
@@ -15,15 +15,32 @@ to download the roads for. Can also be state name or abbreviation
 
 \item{...}{arguments to be passed to internal function \code{load_tiger}, which is not exported. See Additional Arguments.}
 }
+\value{
+an sf object with columns
+\itemize{
+\item \code{LINEARID}: a unique line feature identifier \href{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf}{(source)}
+\item \code{FULLNAME}: display name \href{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf}{(source)}
+\item \code{RTTYP}: describes the types of roads used \href{https://www.census.gov/library/reference/code-lists/route-type-codes.html}{(source)}. Possible values are:
+\itemize{
+\item "C": county
+\item "I": interstate
+\item "M": common name
+\item "O": other
+\item "S": state regonized
+\item "U": U.S.
+}
+\item \code{MTFCC}: 5-digit geographic code assignment \href{https://www.census.gov/library/reference/code-lists/mt-feature-class-codes.html}{(see annual assignments)}
+}
+}
 \description{
 From the Census Bureau: "Primary roads are generally divided,
 limited-access highways within the Federal interstate highway
 system or under state management. These highways are distinguished by the presence of interchanges
 and are accessible by ramps and may include some toll highways. Secondary roads are main arteries,
- usually in the U.S. highway, state
- highway, or county highway system. These roads have one or more lanes of
- traffic in each direction, may
- or may not be divided, and usually have at-grade intersections with many other roads and driveways.
+usually in the U.S. highway, state
+highway, or county highway system. These roads have one or more lanes of
+traffic in each direction, may
+or may not be divided, and usually have at-grade intersections with many other roads and driveways.
 }
 \section{Additional Arguments}{
 

--- a/man/roads.Rd
+++ b/man/roads.Rd
@@ -7,16 +7,33 @@
 roads(state, county, year = NULL, ...)
 }
 \arguments{
-\item{state}{The two-digit FIPS code of the state of the county you'd like
-to download the roads for. Can also be state name or abbreviation
+\item{state}{A character vector of the two-digit FIPS code of the state of the county
+you'd like to download the roads for. Can also be state name or abbreviation
 (case-insensitive).}
 
-\item{county}{The three-digit FIPS code of the county you'd like the roads for.
-Can also be a county name.}
+\item{county}{A character vector of the three-digit FIPS code of the county you'd like
+the roads for. Can also be a county name.}
 
 \item{year}{the data year; defaults to 2021}
 
 \item{...}{arguments to be passed to internal function \code{load_tiger}, which is not exported. See Additional Arguments.}
+}
+\value{
+an sf object with columns
+\itemize{
+\item \code{LINEARID}: a unique line feature identifier \href{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf}{(source)}
+\item \code{FULLNAME}: display name \href{https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2019/TGRSHP2019_TechDoc.pdf}{(source)}
+\item \code{RTTYP}: describes the types of roads used \href{https://www.census.gov/library/reference/code-lists/route-type-codes.html}{(source)}. Possible values are:
+\itemize{
+\item "C": county
+\item "I": interstate
+\item "M": common name
+\item "O": other
+\item "S": state regonized
+\item "U": U.S.
+}
+\item \code{MTFCC}: 5-digit geographic code assignment \href{https://www.census.gov/library/reference/code-lists/mt-feature-class-codes.html}{(see annual assignments)}
+}
 }
 \description{
 From the Census Bureau: "The content of the all roads shapefile includes


### PR DESCRIPTION
This PR documents the output fields from `roads()` and provides links to relevent census documentation. 

This PR:

- adds markdown support to Roxygen
- documents columns from roads and inherits those for primary_roads() and primary_secondary_road()

Important notes:

using markdown will modify all other .Rd files in the man folder by converting things like `my_var` to \code{my_var} for proper rendering. 