### PR TITLE
test on file path for tigris_cache_dir

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -18,6 +18,13 @@
 #' Sys.getenv('TIGRIS_CACHE_DIR')
 #' }
 tigris_cache_dir <- function(path) {
+
+  if (!file.exists(path)) {
+    stop(sprintf(
+      "The path %s does not exist exist.\n",
+      no_path))
+  }
+
   home <- Sys.getenv("HOME")
   renv <- file.path(home, ".Renviron")
   if (!file.exists(renv)) {


### PR DESCRIPTION
Just added a `if stop()` in `tigris_cache_dir()` to check if the user input a correct path before writing it in `.Renviron`. 

This line: https://github.com/walkerke/tigris/blob/0f0d7992e0208b4c55a9fe8ac6c52f9e438a3b0c/R/helpers.R#L81 probably managed to avoid all the `~/somepath` type of errors but I feel it is safer to stop the user before https://github.com/walkerke/tigris/blob/0f0d7992e0208b4c55a9fe8ac6c52f9e438a3b0c/R/helpers.R#L86 create a "weird path". 