### PR TITLE
Merge FTP patch as Census HTTPS site is blocking requests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: tigris
 Type: Package
 Title: Load Census TIGER/Line Shapefiles
-Version: 2.1.2
-Date: 2024-11-04
+Version: 2.2.0
+Date: 2025-04-05
 Authors@R: c(
       person(given="Kyle", family="Walker", email="kyle@walker-data.com", role=c("aut", "cre")),
       person(given="Bob", family="Rudis", email="bob@rudis.net", role="ctb")
@@ -35,5 +35,5 @@ Imports:
     sf, 
     dplyr, 
     methods
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,8 @@ tigris 2.0
 -------------------------------------------------------
 * A new filter_by argument allows users to subset datasets by a bounding box or another sf object when requesting data.
 
+* A new protocol parameter allows users to choose between "ftp" (default) and "http" for downloading files, which can help in environments where HTTPS connections are restricted.
+
 * Deprecation of formal support for sp classes and removal of associated dependencies (rgdal, rgeos, maptools)
 
 * Functions in tigris now default to a year of 2021.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,8 @@ tigris 2.0
 
 * A new protocol parameter allows users to choose between "ftp" (default) and "http" for downloading files, which can help in environments where HTTPS connections are restricted.
 
+* Added a timeout parameter (default: 300 seconds) to handle downloading large files that might take more than the default 60 seconds to download.
+
 * Deprecation of formal support for sp classes and removal of associated dependencies (rgdal, rgeos, maptools)
 
 * Functions in tigris now default to a year of 2021.

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -55,6 +55,7 @@ tigris_cache_dir <- function(path) {
 #' (stored in temporary directory or TIGRIS_CACHE_DIR depending on the configuration of
 #' global option "tigris_use_cache"). Defaults to FALSE.
 #' @param filter_by Geometry used to filter the output returned by the function.  Can be an sf object, an object of class `bbox`, or a length-4 vector of format `c(xmin, ymin, xmax, ymax)` that can be converted to a bbox. Geometries that intersect the input to `filter_by` will be returned.
+#' @param protocol Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 #'
 #' @return sf or sp data frame
 #'
@@ -64,12 +65,18 @@ load_tiger <- function(url,
                        class = getOption("tigris_class", "sf"),
                        progress_bar = TRUE,
                        keep_zipped_shapefile = FALSE,
-                       filter_by = NULL) {
+                       filter_by = NULL,
+                       protocol = "ftp") {
 
   use_cache <- getOption("tigris_use_cache", FALSE)
 
   # Process filter_by
   wkt_filter <- input_to_wkt(filter_by)
+  
+  # Modify URL for FTP if needed
+  if (protocol == "ftp" && grepl("^https://www2", url)) {
+    url <- gsub("^https://www2", "ftp://ftp2", url)
+  }
 
   tiger_file <- basename(url)
 
@@ -96,16 +103,21 @@ load_tiger <- function(url,
 
       if (refresh | !file.exists(shp_loc)) {
 
-        if (progress_bar) {
-          try(GET(url,
-                  write_disk(file_loc, overwrite=refresh),
-                  progress(type="down")), silent=TRUE)
+        if (grepl("^ftp://", url)) {
+          # Use download.file for FTP URLs
+          try(download.file(url, destfile = file_loc, quiet = !progress_bar, mode = "wb"), silent = TRUE)
         } else {
-          try(GET(url,
-                  write_disk(file_loc, overwrite=refresh)),
-                  silent=TRUE)
+          # Use httr::GET for HTTP URLs
+          if (progress_bar) {
+            try(GET(url,
+                    write_disk(file_loc, overwrite=refresh),
+                    progress(type="down")), silent=TRUE)
+          } else {
+            try(GET(url,
+                    write_disk(file_loc, overwrite=refresh)),
+                    silent=TRUE)
+          }
         }
-
 
       }
 
@@ -132,14 +144,20 @@ load_tiger <- function(url,
             message(sprintf("Previous download failed.  Re-download attempt %s of 3...",
                             as.character(i)))
 
-            if (progress_bar) {
-              try(GET(url,
-                      write_disk(file_loc, overwrite=TRUE),
-                      progress(type="down")), silent=TRUE)
+            if (grepl("^ftp://", url)) {
+              # Use download.file for FTP URLs
+              try(download.file(url, destfile = file_loc, quiet = !progress_bar, mode = "wb"), silent = TRUE)
             } else {
-              try(GET(url,
-                      write_disk(file_loc, overwrite=TRUE)),
-                      silent=TRUE)
+              # Use httr::GET for HTTP URLs
+              if (progress_bar) {
+                try(GET(url,
+                        write_disk(file_loc, overwrite=TRUE),
+                        progress(type="down")), silent=TRUE)
+              } else {
+                try(GET(url,
+                        write_disk(file_loc, overwrite=TRUE)),
+                        silent=TRUE)
+              }
             }
 
             t <- tryCatch(unzip_tiger(), warning = function(w) w)
@@ -155,7 +173,7 @@ load_tiger <- function(url,
           if (i == 4) {
 
             stop("Download failed; check your internet connection or the status of the Census Bureau website
-                 at http://www2.census.gov/geo/tiger/.", call. = FALSE)
+                 at https://www2.census.gov/geo/tiger/ or ftp://ftp2.census.gov/geo/tiger/.", call. = FALSE)
           }
 
         } else {
@@ -189,12 +207,18 @@ load_tiger <- function(url,
     tmp <- tempdir()
     file_loc <- file.path(tmp, tiger_file)
 
-    if (progress_bar) {
-      try(GET(url, write_disk(file_loc),
-              progress(type = "down")), silent = TRUE)
+    if (grepl("^ftp://", url)) {
+      # Use download.file for FTP URLs
+      try(download.file(url, destfile = file_loc, quiet = !progress_bar, mode = "wb"), silent = TRUE)
     } else {
-      try(GET(url, write_disk(file_loc)),
-              silent = TRUE)
+      # Use httr::GET for HTTP URLs
+      if (progress_bar) {
+        try(GET(url, write_disk(file_loc),
+                progress(type = "down")), silent = TRUE)
+      } else {
+        try(GET(url, write_disk(file_loc)),
+                silent = TRUE)
+      }
     }
 
     unzip(file_loc, exdir = tmp)
@@ -715,5 +739,6 @@ erase_water <- function(input_sf,
 #'  * `refresh` Whether to re-download cached shapefiles (`TRUE` or `FALSE`) . The default is either `FALSE` or the value of global
 #'     option `"tigris_refresh"` if it is set. Specifying this argument will override the behavior set in `"tigris_refresh"` global option.
 #'  * `filter_by` Geometry used to filter the output returned by the function.  Can be an sf object, an object of class `bbox`, or a length-4 vector of format `c(xmin, ymin, xmax, ymax)` that can be converted to a bbox. Geometries that intersect the input to `filter_by` will be returned.
+#'  * `protocol` Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 #' @name load_tiger_doc_template
 NULL

--- a/R/tigris-package.R
+++ b/R/tigris-package.R
@@ -22,6 +22,10 @@
 #' for downloading files. The default is \code{"ftp"}, which may work better in some environments
 #' where HTTPS connections are restricted. For HTTPS downloads, use \code{protocol = "http"}.
 #'
+#' Use the \code{timeout} parameter to control the timeout for downloading large files. The default is
+#' 300 seconds (5 minutes), which should be sufficient for most files. If you're downloading particularly
+#' large files or have a slow connection, you may need to increase this value.
+#'
 #' @note Several \code{options} and arguments control behavior of various \code{tigris} functions.
 #'       See \code{Details} for more information.
 #' @name tigris

--- a/R/tigris-package.R
+++ b/R/tigris-package.R
@@ -18,7 +18,11 @@
 #' of class \code{Spatial*DataFrame}, use \code{options(tigris_class = "sp")}. Please note
 #' that legacy sp objects are no longer formally supported in tigris.
 #'
-#' @note Four \code{options} control behavior of various \code{tigris} functions.
+#' Use the \code{protocol} argument in data download functions to specify whether to use FTP or HTTP
+#' for downloading files. The default is \code{"ftp"}, which may work better in some environments
+#' where HTTPS connections are restricted. For HTTPS downloads, use \code{protocol = "http"}.
+#'
+#' @note Several \code{options} and arguments control behavior of various \code{tigris} functions.
 #'       See \code{Details} for more information.
 #' @name tigris
 #' @docType package

--- a/man/address_ranges.Rd
+++ b/man/address_ranges.Rd
@@ -32,6 +32,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/address_ranges.Rd
+++ b/man/address_ranges.Rd
@@ -33,6 +33,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/alaska_native_regional_corporations.Rd
+++ b/man/alaska_native_regional_corporations.Rd
@@ -32,6 +32,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/alaska_native_regional_corporations.Rd
+++ b/man/alaska_native_regional_corporations.Rd
@@ -33,6 +33,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/area_water.Rd
+++ b/man/area_water.Rd
@@ -35,6 +35,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/area_water.Rd
+++ b/man/area_water.Rd
@@ -36,6 +36,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/block_groups.Rd
+++ b/man/block_groups.Rd
@@ -58,6 +58,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/block_groups.Rd
+++ b/man/block_groups.Rd
@@ -57,6 +57,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/blocks.Rd
+++ b/man/blocks.Rd
@@ -49,6 +49,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/blocks.Rd
+++ b/man/blocks.Rd
@@ -48,6 +48,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/coastline.Rd
+++ b/man/coastline.Rd
@@ -25,6 +25,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/coastline.Rd
+++ b/man/coastline.Rd
@@ -26,6 +26,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/combined_statistical_areas.Rd
+++ b/man/combined_statistical_areas.Rd
@@ -35,6 +35,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/combined_statistical_areas.Rd
+++ b/man/combined_statistical_areas.Rd
@@ -34,6 +34,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/congressional_districts.Rd
+++ b/man/congressional_districts.Rd
@@ -49,6 +49,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/congressional_districts.Rd
+++ b/man/congressional_districts.Rd
@@ -48,6 +48,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/core_based_statistical_areas.Rd
+++ b/man/core_based_statistical_areas.Rd
@@ -38,6 +38,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/core_based_statistical_areas.Rd
+++ b/man/core_based_statistical_areas.Rd
@@ -37,6 +37,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/counties.Rd
+++ b/man/counties.Rd
@@ -60,6 +60,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/counties.Rd
+++ b/man/counties.Rd
@@ -61,6 +61,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/county_subdivisions.Rd
+++ b/man/county_subdivisions.Rd
@@ -41,6 +41,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/county_subdivisions.Rd
+++ b/man/county_subdivisions.Rd
@@ -40,6 +40,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/divisions.Rd
+++ b/man/divisions.Rd
@@ -29,6 +29,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/divisions.Rd
+++ b/man/divisions.Rd
@@ -28,6 +28,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/landmarks.Rd
+++ b/man/landmarks.Rd
@@ -49,6 +49,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/landmarks.Rd
+++ b/man/landmarks.Rd
@@ -48,6 +48,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/linear_water.Rd
+++ b/man/linear_water.Rd
@@ -38,6 +38,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/linear_water.Rd
+++ b/man/linear_water.Rd
@@ -37,6 +37,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/load_tiger.Rd
+++ b/man/load_tiger.Rd
@@ -12,7 +12,8 @@ load_tiger(
   progress_bar = TRUE,
   keep_zipped_shapefile = FALSE,
   filter_by = NULL,
-  protocol = "ftp"
+  protocol = "ftp",
+  timeout = 300
 )
 }
 \arguments{
@@ -36,6 +37,8 @@ global option "tigris_use_cache"). Defaults to FALSE.}
 \item{filter_by}{Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.}
 
 \item{protocol}{Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.}
+
+\item{timeout}{Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.}
 }
 \value{
 sf or sp data frame

--- a/man/load_tiger.Rd
+++ b/man/load_tiger.Rd
@@ -11,7 +11,8 @@ load_tiger(
   class = getOption("tigris_class", "sf"),
   progress_bar = TRUE,
   keep_zipped_shapefile = FALSE,
-  filter_by = NULL
+  filter_by = NULL,
+  protocol = "ftp"
 )
 }
 \arguments{
@@ -33,6 +34,8 @@ set in "tigris_refresh" option if a value (TRUE or FALSE) is provided.}
 global option "tigris_use_cache"). Defaults to FALSE.}
 
 \item{filter_by}{Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.}
+
+\item{protocol}{Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.}
 }
 \value{
 sf or sp data frame

--- a/man/load_tiger_doc_template.Rd
+++ b/man/load_tiger_doc_template.Rd
@@ -29,6 +29,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/load_tiger_doc_template.Rd
+++ b/man/load_tiger_doc_template.Rd
@@ -28,6 +28,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/metro_divisions.Rd
+++ b/man/metro_divisions.Rd
@@ -27,6 +27,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/metro_divisions.Rd
+++ b/man/metro_divisions.Rd
@@ -26,6 +26,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/military.Rd
+++ b/man/military.Rd
@@ -38,6 +38,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/military.Rd
+++ b/man/military.Rd
@@ -37,6 +37,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/nation.Rd
+++ b/man/nation.Rd
@@ -29,6 +29,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/nation.Rd
+++ b/man/nation.Rd
@@ -28,6 +28,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/native_areas.Rd
+++ b/man/native_areas.Rd
@@ -32,6 +32,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/native_areas.Rd
+++ b/man/native_areas.Rd
@@ -33,6 +33,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/new_england.Rd
+++ b/man/new_england.Rd
@@ -41,6 +41,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/new_england.Rd
+++ b/man/new_england.Rd
@@ -42,6 +42,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/places.Rd
+++ b/man/places.Rd
@@ -35,6 +35,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/places.Rd
+++ b/man/places.Rd
@@ -34,6 +34,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/primary_roads.Rd
+++ b/man/primary_roads.Rd
@@ -46,6 +46,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/primary_roads.Rd
+++ b/man/primary_roads.Rd
@@ -47,6 +47,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/primary_secondary_roads.Rd
+++ b/man/primary_secondary_roads.Rd
@@ -53,6 +53,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/primary_secondary_roads.Rd
+++ b/man/primary_secondary_roads.Rd
@@ -54,6 +54,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/pumas.Rd
+++ b/man/pumas.Rd
@@ -44,6 +44,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/pumas.Rd
+++ b/man/pumas.Rd
@@ -45,6 +45,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/rails.Rd
+++ b/man/rails.Rd
@@ -27,6 +27,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/rails.Rd
+++ b/man/rails.Rd
@@ -26,6 +26,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/regions.Rd
+++ b/man/regions.Rd
@@ -29,6 +29,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/regions.Rd
+++ b/man/regions.Rd
@@ -28,6 +28,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/roads.Rd
+++ b/man/roads.Rd
@@ -52,6 +52,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/roads.Rd
+++ b/man/roads.Rd
@@ -53,6 +53,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/school_districts.Rd
+++ b/man/school_districts.Rd
@@ -49,6 +49,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/school_districts.Rd
+++ b/man/school_districts.Rd
@@ -50,6 +50,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/state_legislative_districts.Rd
+++ b/man/state_legislative_districts.Rd
@@ -46,6 +46,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/state_legislative_districts.Rd
+++ b/man/state_legislative_districts.Rd
@@ -47,6 +47,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/states.Rd
+++ b/man/states.Rd
@@ -35,6 +35,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/states.Rd
+++ b/man/states.Rd
@@ -36,6 +36,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/tigris.Rd
+++ b/man/tigris.Rd
@@ -28,6 +28,10 @@ that legacy sp objects are no longer formally supported in tigris.
 Use the \code{protocol} argument in data download functions to specify whether to use FTP or HTTP
 for downloading files. The default is \code{"ftp"}, which may work better in some environments
 where HTTPS connections are restricted. For HTTPS downloads, use \code{protocol = "http"}.
+
+Use the \code{timeout} parameter to control the timeout for downloading large files. The default is
+300 seconds (5 minutes), which should be sufficient for most files. If you're downloading particularly
+large files or have a slow connection, you may need to increase this value.
 }
 \note{
 Several \code{options} and arguments control behavior of various \code{tigris} functions.

--- a/man/tigris.Rd
+++ b/man/tigris.Rd
@@ -24,9 +24,13 @@ Use option \code{tigris_class} to specify the class of spatial object you'd like
 The default is \code{"sf"} for simple features objects.  If you'd like a legacy object
 of class \code{Spatial*DataFrame}, use \code{options(tigris_class = "sp")}. Please note
 that legacy sp objects are no longer formally supported in tigris.
+
+Use the \code{protocol} argument in data download functions to specify whether to use FTP or HTTP
+for downloading files. The default is \code{"ftp"}, which may work better in some environments
+where HTTPS connections are restricted. For HTTPS downloads, use \code{protocol = "http"}.
 }
 \note{
-Four \code{options} control behavior of various \code{tigris} functions.
+Several \code{options} and arguments control behavior of various \code{tigris} functions.
 See \code{Details} for more information.
 }
 \seealso{

--- a/man/tracts.Rd
+++ b/man/tracts.Rd
@@ -74,6 +74,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/tracts.Rd
+++ b/man/tracts.Rd
@@ -73,6 +73,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/tribal_block_groups.Rd
+++ b/man/tribal_block_groups.Rd
@@ -41,6 +41,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/tribal_block_groups.Rd
+++ b/man/tribal_block_groups.Rd
@@ -42,6 +42,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/tribal_census_tracts.Rd
+++ b/man/tribal_census_tracts.Rd
@@ -36,6 +36,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/tribal_census_tracts.Rd
+++ b/man/tribal_census_tracts.Rd
@@ -37,6 +37,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/tribal_subdivisions_national.Rd
+++ b/man/tribal_subdivisions_national.Rd
@@ -31,6 +31,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/tribal_subdivisions_national.Rd
+++ b/man/tribal_subdivisions_national.Rd
@@ -32,6 +32,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/urban_areas.Rd
+++ b/man/urban_areas.Rd
@@ -33,6 +33,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/urban_areas.Rd
+++ b/man/urban_areas.Rd
@@ -34,6 +34,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/voting_districts.Rd
+++ b/man/voting_districts.Rd
@@ -54,6 +54,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 

--- a/man/voting_districts.Rd
+++ b/man/voting_districts.Rd
@@ -55,6 +55,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/zctas.Rd
+++ b/man/zctas.Rd
@@ -44,6 +44,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
 \item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
+\item \code{timeout} Integer specifying the timeout in seconds for download operations. Defaults to 300 (5 minutes) to handle large files.
 }
 }
 

--- a/man/zctas.Rd
+++ b/man/zctas.Rd
@@ -43,6 +43,7 @@ depending on the configuration of global option \code{"tigris_use_cache"}). Defa
 \item \code{refresh} Whether to re-download cached shapefiles (\code{TRUE} or \code{FALSE}) . The default is either \code{FALSE} or the value of global
 option \code{"tigris_refresh"} if it is set. Specifying this argument will override the behavior set in \code{"tigris_refresh"} global option.
 \item \code{filter_by} Geometry used to filter the output returned by the function.  Can be an sf object, an object of class \code{bbox}, or a length-4 vector of format \code{c(xmin, ymin, xmax, ymax)} that can be converted to a bbox. Geometries that intersect the input to \code{filter_by} will be returned.
+\item \code{protocol} Character string specifying the protocol to use for downloading files. Options are "ftp" (default) or "http". If "ftp", the URL will be modified to use FTP instead of HTTPS.
 }
 }
 


### PR DESCRIPTION
For the past three days (today is April 7 2025) inbound requests to the HTTPS Census site are being blocked.  This patch directs requests by default to the FTP site, which is working, and should allow users to continue to use tigris as normal in the meantime.