### PR TITLE
Fix PUMA TIGER URL for 2024 (use PUMA20 directory)

### DIFF
--- a/R/pumas.R
+++ b/R/pumas.R
@@ -110,8 +110,8 @@ pumas <- function(state = NULL, cb = FALSE, year = NULL, ...) {
             if (year == 2013) url <- gsub("shp/", "", url)
         }
     } else {
-        
-        puma_dir <- if (year > 2021) "PUMA20" else "PUMA"
+
+        puma_dir <- if (year == 2024) "PUMA20" else "PUMA"
         url <- sprintf(
             "https://www2.census.gov/geo/tiger/TIGER%s/%s/tl_%s_%s_puma%s.zip",
             cyear,

--- a/R/pumas.R
+++ b/R/pumas.R
@@ -110,9 +110,12 @@ pumas <- function(state = NULL, cb = FALSE, year = NULL, ...) {
             if (year == 2013) url <- gsub("shp/", "", url)
         }
     } else {
+        
+        puma_dir <- if (year > 2021) "PUMA20" else "PUMA"
         url <- sprintf(
-            "https://www2.census.gov/geo/tiger/TIGER%s/PUMA/tl_%s_%s_puma%s.zip",
+            "https://www2.census.gov/geo/tiger/TIGER%s/%s/tl_%s_%s_puma%s.zip",
             cyear,
+            puma_dir,
             cyear,
             state,
             suf


### PR DESCRIPTION
### Summary
Fixes `tigris::pumas(cb = FALSE, year = 2024)` downloads by using the correct TIGER directory (`PUMA20`) for 2020-based PUMA boundaries. (Closes #213)

### Problem
For 2024 PUMA data, `pumas()` requests `puma20` files (e.g. `tl_2024_18_puma20.zip`) but was constructing URLs under `.../TIGER{year}/PUMA/`, which does not contain those files. This causes download failures with HTTP and FTP fallback.

### HTTP links:

- https://www2.census.gov/geo/tiger/TIGER2021/PUMA/
- https://www2.census.gov/geo/tiger/TIGER2022/PUMA/
- https://www2.census.gov/geo/tiger/TIGER2023/PUMA/
- https://www2.census.gov/geo/tiger/TIGER2024/PUMA20/

### Fix
When `cb = FALSE`:
- Use `PUMA20` directory for `year > 2021`
- Otherwise use `PUMA`
- Preserve the existing filename pattern `tl_<year>_<state>_puma<suf>.zip`

### Repro
```r
library(tigris)
pumas(state = "Indiana", cb = FALSE, year = 2024)
```